### PR TITLE
fix(storybook): import fesm2015 modules if available

### DIFF
--- a/grid-app/.storybook/webpack.config.js
+++ b/grid-app/.storybook/webpack.config.js
@@ -1,0 +1,19 @@
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+
+module.exports = async ({ config }) => {
+  const mainFields = [
+    'es2015',
+    'browser',
+    'module',
+    'main',
+  ];
+
+  config.resolve.plugins = [new TsconfigPathsPlugin({
+    configFile: 'tsconfig.app.json',
+    mainFields
+  })];
+
+  config.resolve.mainFields = mainFields;
+
+  return config;
+};


### PR DESCRIPTION
Workaround Storybook issue by forcing TypeScript to always import ES2015 modules for Kendo UI.

Based on [this block](https://github.com/storybookjs/storybook/blob/master/app/angular/src/server/angular-cli_config.ts#L187) from the Storybook source. Oddly enough, [supportES2015](https://github.com/storybookjs/storybook/blob/master/app/angular/src/server/angular-cli_config.ts#L120) is always set to `false`.